### PR TITLE
Remove dynamic version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,7 @@
 #!/usr/bin/env python
 
-import os
-
 from setuptools import setup
 
-
-VERSION_TEMPLATE = """
-# Note that we need to fall back to the hard-coded version if either
-# setuptools_scm can't be imported or setuptools_scm can't determine the
-# version, so we catch the generic 'Exception'.
-try:
-    from setuptools_scm import get_version
-    __version__ = get_version(root='..', relative_to=__file__)
-except Exception:
-    __version__ = '{version}'
-""".lstrip()
-
 setup(
-    use_scm_version={'write_to': os.path.join('drop_analysis', 'version.py'),
-                     'write_to_template': VERSION_TEMPLATE},
-
+    use_scm_version=True,
 )


### PR DESCRIPTION
This is a brute force solution, and will mean that versions never update after you have run `pip install -e .` even if you pull from git (so the version changes).